### PR TITLE
Feature/card flip

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13529,6 +13529,14 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
+    "react-flippy": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-flippy/-/react-flippy-1.1.0.tgz",
+      "integrity": "sha512-fMaHrGL2HeyYq4ohl65b4EZG5JAawL6NMSiSOhhI68l54nortHvJBqHi5DeR1sF44/4RN2jeNsBXSXuBnOj7Vg==",
+      "requires": {
+        "@babel/runtime": "^7.14.0"
+      }
+    },
     "react-focus-lock": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "jwt-decode": "^3.1.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-flippy": "^1.1.0",
     "react-icons": "^3.11.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^2.1.8",

--- a/client/src/components/Game/index.js
+++ b/client/src/components/Game/index.js
@@ -28,11 +28,13 @@ import Flippy, { FrontSide, BackSide } from 'react-flippy'
 function Game() {
   const [gameStarted, setGameStarted] = useState(false);
     const [question, setQuestion] = useState('Press Start Game to play');
-    const [cardAnswer, setCardAnswer] = useState('');
+    //Answer for Back of Card, not sure why but answer checking if statement won't read this variable properly to check answer always displays as incorrect
+    const [cardAnswer, setCardAnswer] = useState(''); 
     const [options, setOptions] = useState([]);
     const [methods, setMethods] = useState({});
     const [gameMode, setGameMode] = useState(1);
-    let answer;
+    const ref = useRef();
+    let answer; // for answer checking
 
     // Allow toast to work
     const toast = useToast()
@@ -64,14 +66,16 @@ function Game() {
       currentQuestion = Game.renderNext();
       setQuestion(currentQuestion.question);
       setOptions(currentQuestion.options);
-      setCardAnswer(currentQuestion.answer);
-      answer = currentQuestion.answer;
-      console.log(answer);
+      setCardAnswer(currentQuestion.answer); //put answer on back of card
+      answer = currentQuestion.answer; //load correct answer for if statement below
+      
 
       return {
         handleInput(e) {
           const userInput = e.target.textContent;
           const isCorrect = answer === userInput;
+          ref.current.toggle()
+          
           Game.isCorrect(isCorrect);
           toast({
             title: `${isCorrect ? 'Correct' : 'Incorrect'}`,
@@ -86,9 +90,10 @@ function Game() {
             currentQuestion = Game.renderNext();
             setQuestion(currentQuestion.question);
             setOptions(currentQuestion.options);
-            setCardAnswer(currentQuestion.answer);
-            answer = currentQuestion.answer;
-            console.log(answer);
+            setTimeout(() => {
+              setCardAnswer(currentQuestion.answer);
+            }, 1000)            
+            answer = currentQuestion.answer;            
           } else {
             window.location.replace('/profile');
           }
@@ -182,11 +187,16 @@ function Game() {
       </Box>}
 
         <Box>
+          
         <Wrap  direction="column"  justify="space-between" align="center">
-        <Flippy>
-        <FrontSide>
+        <Flippy
+        flipOnHover={false}
+        flipOnClick={false}
+        ref={ref}>        
+        <FrontSide
+        style={{ backgroundColor: "#FEB2B2", borderRadius: "0.5rem", boxShadow: "5px 10px 10px 5px grey"}}>
             <WrapItem 
-            boxShadow="2xl"
+            //boxShadow="2xl"
             bg="red.200"
             maxW="sm"
             borderRadius="lg" 
@@ -196,9 +206,11 @@ function Game() {
               </Center>              
             </WrapItem>
             </FrontSide>
-            <BackSide>
+            <BackSide
+            animationDuration={600}
+            style={{ backgroundColor: "#FEB2B2", borderRadius: "0.5rem", boxShadow: "5px 10px 10px 5px grey"}}>
             <WrapItem 
-            boxShadow="2xl"
+            //boxShadow="2xl"
             bg="red.200"
             maxW="sm"
             borderRadius="lg" 
@@ -207,9 +219,10 @@ function Game() {
                 {cardAnswer}            
               </Center>            
             </WrapItem>
-            </BackSide>
+            </BackSide>          
         </Flippy>
         </Wrap>
+       
 
         <Wrap  direction="row"  justify="space-evenly" align="center" mt={5}>
           {options.map(option => (
@@ -217,7 +230,11 @@ function Game() {
               <Button 
               boxShadow="2xl"  
               onClick={e => {
-                methods.handleInput(e)
+                
+                ref.current.toggle();
+                setTimeout(() => {
+                  methods.handleInput(e); 
+                }, 1000)                 
               }}
               >
                 {option}

--- a/client/src/components/Game/index.js
+++ b/client/src/components/Game/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import GameSession from '../../utils/gameLogic';
 import { useQuery } from '@apollo/react-hooks';
 import { GET_DECKS, GET_DECK_ID } from "../../utils/queries";
@@ -21,15 +21,18 @@ import {
     useToast,
     toast
 } from '@chakra-ui/react';
+import Flippy, { FrontSide, BackSide } from 'react-flippy'
 
 
 
 function Game() {
   const [gameStarted, setGameStarted] = useState(false);
     const [question, setQuestion] = useState('Press Start Game to play');
+    const [cardAnswer, setCardAnswer] = useState('');
     const [options, setOptions] = useState([]);
     const [methods, setMethods] = useState({});
     const [gameMode, setGameMode] = useState(1);
+    let answer;
 
     // Allow toast to work
     const toast = useToast()
@@ -61,7 +64,9 @@ function Game() {
       currentQuestion = Game.renderNext();
       setQuestion(currentQuestion.question);
       setOptions(currentQuestion.options);
-      let answer = currentQuestion.answer;
+      setCardAnswer(currentQuestion.answer);
+      answer = currentQuestion.answer;
+      console.log(answer);
 
       return {
         handleInput(e) {
@@ -81,7 +86,9 @@ function Game() {
             currentQuestion = Game.renderNext();
             setQuestion(currentQuestion.question);
             setOptions(currentQuestion.options);
+            setCardAnswer(currentQuestion.answer);
             answer = currentQuestion.answer;
+            console.log(answer);
           } else {
             window.location.replace('/profile');
           }
@@ -176,17 +183,32 @@ function Game() {
 
         <Box>
         <Wrap  direction="column"  justify="space-between" align="center">
+        <Flippy>
+        <FrontSide>
             <WrapItem 
             boxShadow="2xl"
             bg="red.200"
             maxW="sm"
             borderRadius="lg" 
             overflow="hidden">
-              <Center w="350px" h="400px" bg="red.200">
-                {question}
-              </Center>
+              <Center w="350px" h="400px">                  
+                {question}                
+              </Center>              
             </WrapItem>
-
+            </FrontSide>
+            <BackSide>
+            <WrapItem 
+            boxShadow="2xl"
+            bg="red.200"
+            maxW="sm"
+            borderRadius="lg" 
+            overflow="hidden">
+              <Center w="350px" h="400px">
+                {cardAnswer}            
+              </Center>            
+            </WrapItem>
+            </BackSide>
+        </Flippy>
         </Wrap>
 
         <Wrap  direction="row"  justify="space-evenly" align="center" mt={5}>


### PR DESCRIPTION
Added card flipping animation to Game, After clicking an answer the card will flip over to show the correct answer and then after 1 second will flip back around with the next question. I used setTimeout functions to get the desired effect and delay the execution of rendering the next card so that the card would already be flipping back around when the next cards data is being loaded. 

I had to manually style the cards in the react-Flippy tags as it was not cooperating nicely with the Chakra Wrap and Wrap Item Elements that were housing the card data. 